### PR TITLE
fix backwards link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Bluetooth connection between your smartphone and your VanMoof is encrypted f
 
 With this tool, we want to make sure everyone can use their VanMoof even after these servers become unreachable - preventing e-waste.
 
-We encourage self hosting this tool, however, if you do not have the technical resources, you can use the version hosted on our server at [https://vanoof.grossartig.io](vanoof.grossartig.io)
+We encourage self hosting this tool, however, if you do not have the technical resources, you can use the version hosted on our server at [vanoof.grossartig.io](https://vanoof.grossartig.io)
 
 vanoof.grossartig.io does not store any personal data. Our server acts as a proxy to VanMoof's API as it only allows Access-Control-Allow-Origin: * headers.
 


### PR DESCRIPTION
The link to the hosted version lead to a 404 on github.com, this makes it go to the right place.